### PR TITLE
Modified CircularBuffer to limit its Read output to the amount written ...

### DIFF
--- a/SharedMemory/CircularBuffer.cs
+++ b/SharedMemory/CircularBuffer.cs
@@ -199,7 +199,6 @@ namespace SharedMemory
             /// <summary>
             /// Holds the number of bytes written into this node.
             /// </summary>
-            //int _padding0;
             public int AmountWritten;
         }
 

--- a/SharedMemory/CircularBuffer.cs
+++ b/SharedMemory/CircularBuffer.cs
@@ -199,7 +199,8 @@ namespace SharedMemory
             /// <summary>
             /// Pad out the structure to 32-bytes.
             /// </summary>
-            int _padding0;
+            //int _padding0;
+            public int amount_written;
         }
 
         #endregion
@@ -450,6 +451,8 @@ namespace SharedMemory
             int amount = Math.Min(buffer.Length, NodeBufferSize);
             
             Marshal.Copy(buffer, 0, new IntPtr(BufferStartPtr + node->Offset), amount);
+            node->amount_written = amount;
+            
 
             // Writing is complete, make readable
             PostNode(node);
@@ -474,6 +477,7 @@ namespace SharedMemory
             // Write the data using the FastStructure class (much faster than the MemoryMappedViewAccessor WriteArray<T> method)
             int amount = Math.Min(buffer.Length, NodeBufferSize / FastStructure.SizeOf<T>());
             base.WriteArray<T>(node->Offset, buffer, 0, amount);
+            node->amount_written = amount * FastStructure.SizeOf<T>();
 
             // Writing is complete, make node readable
             PostNode(node);
@@ -502,6 +506,7 @@ namespace SharedMemory
 
             // Copy the data using the MemoryMappedViewAccessor
             base.Write<T>(ref data, node->Offset);
+            node->amount_written = structSize;
 
             // Return the node for further writing
             PostNode(node);
@@ -526,6 +531,7 @@ namespace SharedMemory
             // Copy the data
             int amount = Math.Min(length, NodeBufferSize);
             base.Write(bufferPtr, amount, node->Offset);
+            node->amount_written = amount;
 
             // Writing is complete, make readable
             PostNode(node);
@@ -551,6 +557,7 @@ namespace SharedMemory
             {
                 // Pass destination IntPtr to custom write function
                 amount = writeFunc(new IntPtr(BufferStartPtr + node->Offset));
+                node->amount_written = amount;
             }
             finally
             {
@@ -650,8 +657,9 @@ namespace SharedMemory
             Node* node = GetNodeForReading(timeout);
             if (node == null) return 0;
 
-            int amount = Math.Min(buffer.Length, NodeBufferSize);
-            
+            //int amount = Math.Min(buffer.Length, NodeBufferSize);
+            int amount = Math.Min(buffer.Length, node->amount_written);
+
             // Copy the data
             Marshal.Copy(new IntPtr(BufferStartPtr + node->Offset), buffer, 0, amount);
 
@@ -676,7 +684,8 @@ namespace SharedMemory
             if (node == null) return 0;
 
             // Copy the data using the FastStructure class (much faster than the MemoryMappedViewAccessor ReadArray<T> method)
-            int amount = Math.Min(buffer.Length, NodeBufferSize / FastStructure.SizeOf<T>());
+            //int amount = Math.Min(buffer.Length, NodeBufferSize / FastStructure.SizeOf<T>());
+            int amount = Math.Min(buffer.Length, node->amount_written / FastStructure.SizeOf<T>());
             base.ReadArray<T>(buffer, node->Offset, 0, amount);
 
             // Return the node for further writing
@@ -730,7 +739,9 @@ namespace SharedMemory
             Node* node = GetNodeForReading(timeout);
             if (node == null) return 0;
 
-            int amount = Math.Min(length, NodeBufferSize);
+            //int amount = Math.Min(length, NodeBufferSize);
+            int amount = Math.Min(length, node->amount_written);
+
             // Copy the data
             base.Read(buffer, amount, node->Offset);
 


### PR DESCRIPTION
…to the node instead of the whole NodeBufferSize.

Replaced _padding0 in the Node struct with amount_written;
updated the Write functions to assign node->amount_written based on the amount written;
updated the Read functions to use node->amount_written in place of NodeBufferSize when figuring out how much data to return.