### PR TITLE
Fix my test struct

### DIFF
--- a/SharedMemory/Array.cs
+++ b/SharedMemory/Array.cs
@@ -40,7 +40,7 @@ namespace SharedMemory
     /// <typeparam name="T">The struct type that will be stored in the elements of this fixed array buffer.</typeparam>
     [PermissionSet(SecurityAction.LinkDemand)]
     [PermissionSet(SecurityAction.InheritanceDemand)]
-    public class Array<T> : BufferWithLocks, IEnumerable<T>
+    public class Array<T> : BufferWithLocks, IList<T>
             where T : struct
     {
         /// <summary>
@@ -211,5 +211,56 @@ namespace SharedMemory
         }
 
         #endregion
+
+        #region IList<T>
+        public void Add(T item)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool Contains(T item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public bool Remove(T item)
+        {
+            throw new NotImplementedException();
+        }
+
+        public int Count
+        {
+            get { return Length; }
+        }
+
+        public bool IsReadOnly
+        {
+            get { return true; }
+        }
+        public int IndexOf(T item)
+        {
+            for (var i = 0; i < Count; i++)
+            {
+                if (this[i].Equals(item)) return i;
+            }
+            return -1;
+        }
+
+        public void Insert(int index, T item)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotImplementedException();
+        }
+        #endregion
+
     }
 }

--- a/SharedMemoryTests/ArrayTests.cs
+++ b/SharedMemoryTests/ArrayTests.cs
@@ -25,6 +25,7 @@
 //   http://www.codeproject.com/Articles/14740/Fast-IPC-Communication-Using-Shared-Memory-and-Int
 
 using System;
+using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SharedMemory;
 using System.Runtime.InteropServices;
@@ -50,6 +51,20 @@ namespace SharedMemoryTests
                     Assert.AreEqual(3, smr[0], "");
                     Assert.AreEqual(10, smr[4], "");
                 }
+
+                IList<int> a = sma;
+                a[0] = 3;
+                a[4] = 10;
+
+                using (var smr = new Array<int>(name))
+                {
+                    IList<int> r = smr;
+
+                    Assert.AreEqual(0, r[1], "");
+                    Assert.AreEqual(3, r[0], "");
+                    Assert.AreEqual(10, r[4], "");
+                }
+
             }
         }
 
@@ -71,10 +86,36 @@ namespace SharedMemoryTests
 
                 Assert.IsTrue(exceptionThrown, "Index of -1 should result in ArgumentOutOfRangeException");
 
+                exceptionThrown = false;
+                IList<int> a = sma;
+                try
+                {
+                    a[-1] = 0;
+                }
+                catch (ArgumentOutOfRangeException)
+                {
+                    exceptionThrown = true;
+                }
+
+                Assert.IsTrue(exceptionThrown, "Index of -1 should result in ArgumentOutOfRangeException");
+
                 try
                 {
                     exceptionThrown = false;
                     sma[sma.Length] = 0;
+                }
+                catch (ArgumentOutOfRangeException)
+                {
+                    exceptionThrown = true;
+                }
+
+                Assert.IsTrue(exceptionThrown, "Index of Length should result in ArgumentOutOfRangeException");
+
+
+                try
+                {
+                    exceptionThrown = false;
+                    a[a.Count] = 0;
                 }
                 catch (ArgumentOutOfRangeException)
                 {
@@ -295,6 +336,52 @@ namespace SharedMemoryTests
 
                     smr.ReleaseReadLock();
                 }
+            }
+        }
+
+        [TestMethod]
+        public void IList_Contains()
+        {
+            var name = Guid.NewGuid().ToString();
+            using (var sma = new Array<int>(name, 10))
+            {
+                sma[0] = 3;
+                sma[4] = 10;
+
+                IList<int> a = sma;
+
+                Assert.IsTrue(a.Contains(10));
+                Assert.IsFalse(a.Contains(11));
+            }
+        }
+
+        [TestMethod]
+        public void IList_IndexOf()
+        {
+            var name = Guid.NewGuid().ToString();
+            using (var sma = new Array<int>(name, 10))
+            {
+                sma[0] = 3;
+                sma[4] = 10;
+
+                IList<int> a = sma;
+
+                Assert.AreEqual(4, a.IndexOf(10));
+                Assert.AreEqual(-1, a.IndexOf(11));
+            }
+        }
+
+        [TestMethod]
+        public void IList_IsReadOnly()
+        {
+            var name = Guid.NewGuid().ToString();
+            using (var sma = new Array<int>(name, 10))
+            {
+                sma[0] = 3;
+                sma[4] = 10;
+
+                IList<int> a = sma;
+                Assert.IsTrue(a.IsReadOnly);
             }
         }
     }

--- a/SharedMemoryTests/ArrayTests.cs
+++ b/SharedMemoryTests/ArrayTests.cs
@@ -112,9 +112,10 @@ namespace SharedMemoryTests
                         {
                             *(n + indx) = c;
                             indx++;
-                            if (indx >= MAXLENGTH)
+                            if (indx >= MAXLENGTH - 1)
                                 break;
                         }
+                        *(n + indx) = '\0';
                     }
                 }
             }

--- a/SharedMemoryTests/ArrayTests.cs
+++ b/SharedMemoryTests/ArrayTests.cs
@@ -121,6 +121,15 @@ namespace SharedMemoryTests
         }
 
         [TestMethod]
+        public void Test_MyTestStruct()
+        {
+            var my = new MyTestStruct();
+            my.Name = "long string long string";
+            my.Name = "short string";
+            Assert.AreEqual("short string", my.Name);
+        }
+
+        [TestMethod]
         public void Indexer_ReadWriteComplexStruct_DataMatches()
         {
             var name = Guid.NewGuid().ToString();


### PR DESCRIPTION
The MyTestStruct example in the test code had a minor bug in it in that it didn't handle null-termination.   This could possibly cause a crash if string of exactly 100 characters were used, or if you set the Name field to a shorter string after setting to a longer string.

Realizing that this struct only exists for test code, I don't think it's that big of a deal.   But I wanted to get this in anyway because that sample code is something other people may use as a basis of their own implementation, so might as well have the bug fixed.