### PR TITLE
Add ArraySlice, supports IList, and can work with Shared Array.

### DIFF
--- a/SharedMemory/SharedMemory.csproj
+++ b/SharedMemory/SharedMemory.csproj
@@ -42,6 +42,7 @@
     <Compile Include="Array.cs" />
     <Compile Include="Buffer.cs" />
     <Compile Include="UnsafeNativeMethods.cs" />
+    <Compile Include="Utilities\ArraySlice.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="publickey.snk" />

--- a/SharedMemory/Utilities/ArraySlice.cs
+++ b/SharedMemory/Utilities/ArraySlice.cs
@@ -1,0 +1,307 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Security.Permissions;
+
+namespace SharedMemory.Utilities
+{
+    /// <summary>
+    /// Like ArraySegment, but works with any IList, not just array
+    /// </summary>
+    /// <typeparam name="T">The type that will be stored in the elements of this fixed array buffer.</typeparam>
+    [PermissionSet(SecurityAction.LinkDemand)]
+    [PermissionSet(SecurityAction.InheritanceDemand)]
+    public struct ArraySlice<T> : IList<T>
+
+    {
+        private readonly IList<T> _list;
+        private readonly int _offset;
+        private readonly int _count;
+
+        /// <summary>
+        /// No slicing.  Just mirror the array
+        /// </summary>
+        /// <param name="list"></param>
+        /// <exception cref="ArgumentNullException"></exception>
+        public ArraySlice(IList<T> list)
+        {
+            if (list == null)
+                throw new ArgumentNullException("list");
+
+            _list = list;
+            _offset = 0;
+            _count = list.Count;
+        }
+
+        /// <summary>
+        /// Slice the array.
+        /// </summary>
+        /// <param name="list"></param>
+        /// <param name="offset"></param>
+        /// <param name="count"></param>
+        /// <exception cref="ArgumentNullException"></exception>
+        /// <exception cref="ArgumentOutOfRangeException"></exception>
+        /// <exception cref="ArgumentException"></exception>
+        public ArraySlice(IList<T> list, int offset, int count)
+        {
+            if (list == null)
+                throw new ArgumentNullException("list");
+            if (offset < 0)
+                throw new ArgumentOutOfRangeException("offset", "ArgumentOutOfRange_NeedNonNegNum");
+            if (count < 0)
+                throw new ArgumentOutOfRangeException("count", "ArgumentOutOfRange_NeedNonNegNum");
+            if (list.Count - offset < count)
+                throw new ArgumentException("Argument_InvalidOffLen");
+
+            _list = list;
+            _offset = offset;
+            _count = count;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public IList<T> List
+        {
+            get
+            {
+                return _list;
+            }
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public int Offset
+        {
+            get
+            {
+                return _offset;
+            }
+        }
+
+        public int Count
+        {
+            get
+            {
+                return _count;
+            }
+        }
+
+        public override int GetHashCode()
+        {
+            return null == _list
+                        ? 0
+                        : _list.GetHashCode() ^ _offset ^ _count;
+        }
+
+        /// <summary>Indicates whether this instance and a specified object are equal.</summary>
+        /// <returns>true if <paramref name="obj" /> and this instance are the same type and represent the same value; otherwise, false.</returns>
+        /// <param name="obj">Another object to compare to. </param>
+        /// <filterpriority>2</filterpriority>
+        public override bool Equals(Object obj)
+        {
+            if (obj is ArraySlice<T>)
+                return Equals((ArraySlice<T>)obj);
+            else
+                return false;
+        }
+
+        /// <summary>Indicates whether this instance and a specified object are equal.</summary>
+        /// <param name="obj"></param>
+        /// <returns></returns>
+        public bool Equals(ArraySlice<T> obj)
+        {
+            return obj._list == _list && obj._offset == _offset && obj._count == _count;
+        }
+
+        /// <summary>Indicates whether this instance and a specified object are equal.</summary>
+        /// <param name="a"></param>
+        /// <param name="b"></param>
+        /// <returns></returns>
+        public static bool operator ==(ArraySlice<T> a, ArraySlice<T> b)
+        {
+            return a.Equals(b);
+        }
+
+        /// <summary>Indicates whether this instance and a specified object are not equal.</summary>
+        /// <param name="a"></param>
+        /// <param name="b"></param>
+        /// <returns></returns>
+        public static bool operator !=(ArraySlice<T> a, ArraySlice<T> b)
+        {
+            return !(a == b);
+        }
+
+        #region IList<T>
+
+        /// <summary>Gets or sets the element at the specified index.</summary>
+        /// <returns>The element at the specified index.</returns>
+        /// <param name="index">The zero-based index of the element to get or set.</param>
+        /// <exception cref="T:System.ArgumentOutOfRangeException">
+        /// <paramref name="index" /> is not a valid index in the <see cref="T:System.Collections.Generic.IList`1" />.</exception>
+        /// <exception cref="T:System.NotSupportedException">The property is set and the <see cref="T:System.Collections.Generic.IList`1" /> is read-only.</exception>
+        public T this[int index]
+        {
+            get
+            {
+                if (_list == null)
+                    throw new InvalidOperationException("InvalidOperation_NullArray");
+                if (index < 0 || index >= _count)
+                    throw new ArgumentOutOfRangeException("index");
+
+                return _list[_offset + index];
+            }
+
+            set
+            {
+                if (_list == null)
+                    throw new InvalidOperationException("InvalidOperation_NullArray");
+                if (index < 0 || index >= _count)
+                    throw new ArgumentOutOfRangeException("index");
+
+                _list[_offset + index] = value;
+            }
+        }
+
+        /// <summary>Determines the index of a specific item in the <see cref="T:System.Collections.Generic.IList`1" />.</summary>
+        /// <returns>The index of <paramref name="item" /> if found in the list; otherwise, -1.</returns>
+        /// <param name="item">The object to locate in the <see cref="T:System.Collections.Generic.IList`1" />.</param>
+        public int IndexOf(T item)
+        {
+            if (_list == null)
+                throw new InvalidOperationException("InvalidOperation_NullArray");
+
+            for (var i = 0; i < Count; i++)
+            {
+                if (this[i].Equals(item)) return i;
+            }
+            return -1;
+        }
+
+        void IList<T>.Insert(int index, T item)
+        {
+            throw new NotSupportedException();
+        }
+
+        void IList<T>.RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+        #endregion
+
+        #region ICollection<T>
+        bool ICollection<T>.IsReadOnly
+        {
+            get
+            {
+                // the indexer setter does not throw an exception although IsReadOnly is true.
+                // This is to match the behavior of arrays.
+                return true;
+            }
+        }
+
+        void ICollection<T>.Add(T item)
+        {
+            throw new NotSupportedException();
+        }
+
+        void ICollection<T>.Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        bool ICollection<T>.Contains(T item)
+        {
+            if (_list == null)
+                throw new InvalidOperationException("InvalidOperation_NullArray");
+
+            return IndexOf(item) >= 0;
+        }
+
+        void ICollection<T>.CopyTo(T[] array, int arrayIndex)
+        {
+            throw new NotSupportedException();
+        }
+
+        bool ICollection<T>.Remove(T item)
+        {
+            throw new NotSupportedException();
+        }
+        #endregion
+
+        #region IEnumerable<T>
+        IEnumerator<T> IEnumerable<T>.GetEnumerator()
+        {
+            if (_list == null)
+                throw new InvalidOperationException("InvalidOperation_NullArray");
+
+            return new ArraySliceEnumerator(this);
+        }
+        #endregion
+
+        #region IEnumerable
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            if (_list == null)
+                throw new InvalidOperationException("InvalidOperation_NullArray");
+
+            return new ArraySliceEnumerator(this);
+        }
+        #endregion
+
+        [Serializable]
+        private sealed class ArraySliceEnumerator : IEnumerator<T>
+        {
+            private IList<T> _array;
+            private int _start;
+            private int _end;
+            private int _current;
+
+            internal ArraySliceEnumerator(ArraySlice<T> arraySlice)
+            {
+                _array = arraySlice._list;
+                _start = arraySlice._offset;
+                _end = _start + arraySlice._count;
+                _current = _start - 1;
+            }
+
+            public bool MoveNext()
+            {
+                if (_current < _end)
+                {
+                    _current++;
+                    return _current < _end;
+                }
+                return false;
+            }
+
+            public T Current
+            {
+                get
+                {
+                    if (_current < _start) throw new InvalidOperationException("InvalidOperation_EnumNotStarted");
+                    if (_current >= _end) throw new InvalidOperationException("InvalidOperation_EnumEnded");
+                    return _array[_current];
+                }
+            }
+
+            object IEnumerator.Current
+            {
+                get
+                {
+                    return Current;
+                }
+            }
+
+            void IEnumerator.Reset()
+            {
+                _current = _start - 1;
+            }
+
+            public void Dispose()
+            {
+            }
+        }
+    }
+}

--- a/SharedMemoryTests/ArraySliceTests.cs
+++ b/SharedMemoryTests/ArraySliceTests.cs
@@ -1,0 +1,119 @@
+﻿// SharedMemory (File: SharedMemoryTests\ArrayTests.cs)
+// Copyright (c) 2014 Justin Stenning
+// http://spazzarama.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// The SharedMemory library is inspired by the following Code Project article:
+//   "Fast IPC Communication Using Shared Memory and InterlockedCompareExchange"
+//   http://www.codeproject.com/Articles/14740/Fast-IPC-Communication-Using-Shared-Memory-and-Int
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SharedMemory.Utilities;
+
+namespace SharedMemoryTests
+{
+    [TestClass]
+    public class ArraySliceTests
+    {
+        [TestMethod]
+        public void ArraySlice_WorksLikeArray()
+        {
+            var a = new[] {1.0, 2.71828, 3.14, 4, 4.99999, 42, 1024};
+            var slicea = new ArraySlice<double>(a);
+            var sliceaSame = new ArraySlice<double>(a);
+
+            var b = new[] { 1.0, 2, 3, 4, 5, 99, 1024 };
+            var sliceb = new ArraySlice<double>(b);
+
+            Assert.AreEqual(a, slicea.List);
+            Assert.AreEqual(0, slicea.Offset);
+            Assert.AreEqual(7, slicea.Count);
+            Assert.IsTrue(slicea.Equals(sliceaSame));
+            Assert.IsTrue(slicea.Equals((object)sliceaSame));
+            Assert.AreEqual(sliceaSame.GetHashCode(), sliceaSame.GetHashCode());
+            Assert.IsTrue(slicea == sliceaSame);
+            Assert.IsTrue(slicea != sliceb);
+
+            Assert.IsTrue(ApproximatelyEqual(4, slicea[3]));
+            Assert.AreEqual(6, slicea.IndexOf(1024));
+            Assert.AreEqual(-1, slicea.IndexOf(1025));
+            Assert.IsTrue(slicea.Contains(1024));
+            Assert.IsFalse(slicea.Contains(1025));
+            Assert.IsTrue(ApproximatelyEqual(1081.85827, slicea.Sum()));
+
+            IList<double> asList = slicea;
+
+            Assert.IsTrue(ApproximatelyEqual(4, asList[3]));
+            Assert.AreEqual(6, asList.IndexOf(1024));
+            Assert.AreEqual(-1, asList.IndexOf(1025));
+            Assert.IsTrue(asList.Contains(1024));
+            Assert.IsFalse(asList.Contains(1025));
+            Assert.IsTrue(ApproximatelyEqual(1081.85827, asList.Sum()));
+        }
+
+        [TestMethod]
+        public void ArraySlice_TestSlice()
+        {
+            var a = new[] { 1.0, 2.71828, 3.14, 4, 4.99999, 42, 1024 };
+            var slicea = new ArraySlice<double>(a, 2, 3);
+            var sliceaSame = new ArraySlice<double>(a, 2, 3);
+
+            var b = new[] { 1.0, 2, 3, 4, 5, 99, 1024 };
+            var sliceb = new ArraySlice<double>(b, 2, 3);
+
+            Assert.AreEqual(a, slicea.List);
+            Assert.AreEqual(2, slicea.Offset);
+            Assert.AreEqual(3, slicea.Count);
+            Assert.IsTrue(slicea.Equals(sliceaSame));
+            Assert.IsTrue(slicea.Equals((object)sliceaSame));
+            Assert.AreEqual(sliceaSame.GetHashCode(), sliceaSame.GetHashCode());
+            Assert.IsTrue(slicea == sliceaSame);
+            Assert.IsTrue(slicea != sliceb);
+
+            Assert.IsTrue(ApproximatelyEqual(4.99999, slicea[2]));
+            Assert.AreEqual(1, slicea.IndexOf(4));
+            Assert.AreEqual(-1, slicea.IndexOf(1025));
+            Assert.IsTrue(slicea.Contains(4));
+            Assert.IsFalse(slicea.Contains(1025));
+            Assert.IsTrue(ApproximatelyEqual(12.13999, slicea.Sum()));
+
+            IList<double> asList = slicea;
+
+            Assert.IsTrue(ApproximatelyEqual(4.99999, asList[2]));
+            Assert.AreEqual(1, asList.IndexOf(4));
+            Assert.AreEqual(-1, asList.IndexOf(1025));
+            Assert.IsTrue(asList.Contains(4));
+            Assert.IsFalse(asList.Contains(1025));
+            Assert.IsTrue(ApproximatelyEqual(12.13999, asList.Sum()));
+        }
+
+
+
+        // http://stackoverflow.com/a/2411661/75129
+        public static bool ApproximatelyEqual(double x, double y)
+        {
+            var epsilon = Math.Max(Math.Abs(x), Math.Abs(y)) * 1E-15;
+            return Math.Abs(x - y) <= epsilon;
+        }
+    }
+}

--- a/SharedMemoryTests/ArrayTests.cs
+++ b/SharedMemoryTests/ArrayTests.cs
@@ -30,6 +30,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SharedMemory;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
+using SharedMemory.Utilities;
 
 namespace SharedMemoryTests
 {

--- a/SharedMemoryTests/ArrayTests.cs
+++ b/SharedMemoryTests/ArrayTests.cs
@@ -52,17 +52,31 @@ namespace SharedMemoryTests
                     Assert.AreEqual(10, smr[4], "");
                 }
 
-                IList<int> a = sma;
-                a[0] = 3;
-                a[4] = 10;
+                IList<int> list = sma;
+                list[0] = 5;
+                list[4] = 55;
 
                 using (var smr = new Array<int>(name))
                 {
                     IList<int> r = smr;
 
                     Assert.AreEqual(0, r[1], "");
-                    Assert.AreEqual(3, r[0], "");
-                    Assert.AreEqual(10, r[4], "");
+                    Assert.AreEqual(5, r[0], "");
+                    Assert.AreEqual(55, r[4], "");
+                }
+
+                list[3] = 68;
+                IList<int> arraySlice = new ArraySlice<int>(list, 1, 8);
+                arraySlice[0] = 67;
+
+                using (var smr = new Array<int>(name))
+                {
+                    IList<int> r = smr;
+                    IList<int> rarraySlice = new ArraySlice<int>(r, 1, 8);
+
+                    Assert.AreEqual(67, rarraySlice[0], "");
+                    Assert.AreEqual(68, rarraySlice[2], "");
+                    Assert.AreEqual(55, rarraySlice[3], "");
                 }
 
             }

--- a/SharedMemoryTests/SharedMemoryTests.csproj
+++ b/SharedMemoryTests/SharedMemoryTests.csproj
@@ -75,6 +75,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
+    <Compile Include="ArraySliceTests.cs" />
     <Compile Include="CircularBufferTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ArrayTests.cs" />


### PR DESCRIPTION
This is an ArraySlice implementation based on .NET's own ArraySegment.  It's been modified to support any IList rather than require an array.   The benefit is that it can now work with Shared Array because it supports IList.

ArraySlice implements IList, so to an application, it can easily be replaced where you typically would use an array.

The benefit of ArraySlice is that you can create a single large array and then smaller arrays refer to parts of the larger array.   One advantage of this is that if you have a lot of small arrays, you don't incur the overhead of creating a Shared Array which has the overhead of its own memory mapped file.  Every SharedArray takes 500-600 bytes (on 64-bit) regardless of the actual size of the array.