### PR TITLE
Make unit tests work in 64-bit mode.

### DIFF
--- a/SharedMemoryTests/CircularBufferTests.cs
+++ b/SharedMemoryTests/CircularBufferTests.cs
@@ -192,6 +192,11 @@ namespace SharedMemoryTests
         [TestMethod]
         public void Constructor_BufferTooLarge_ArgumentOutOfRangeException()
         {
+            // If it's not 32-bit build, then we can't test for out-of-range.
+            // Test below always succeeds on 64-bit systems.
+
+            if (IntPtr.Size != sizeof(int)) return;
+
             string name = Guid.NewGuid().ToString();
             try
             {


### PR DESCRIPTION
Unit test Constructor_BufferTooLarge_ArgumentOutOfRangeException was failing in 64-bit mode because test code was incorrectly assuming you can create buffer bigger than int.MaxValue.

Fixed in this pull request.