### PR TITLE
Support file-backed memory mapped file

### DIFF
--- a/SharedMemory/Array.cs
+++ b/SharedMemory/Array.cs
@@ -74,8 +74,17 @@ namespace SharedMemory
         /// </summary>
         /// <param name="name">The name of the shared memory array to be created.</param>
         /// <param name="length">The number of elements to make room for within the shared memory array.</param>
+        public Array(string name, int length, string fileName)
+            : base(name, Marshal.SizeOf(typeof(T)) * length, true, fileName)
+        {
+            Length = length;
+            _elementSize = Marshal.SizeOf(typeof(T));
+
+            Open();
+        }
+
         public Array(string name, int length)
-            : base(name, Marshal.SizeOf(typeof(T)) * length, true)
+            : base(name, Marshal.SizeOf(typeof(T)) * length, true, NoFile)
         {
             Length = length;
             _elementSize = Marshal.SizeOf(typeof(T));
@@ -89,7 +98,7 @@ namespace SharedMemory
         /// <param name="name">The name of the shared memory array to open.</param>
         /// <exception cref="ArgumentOutOfRangeException">If the shared memory location specified by <paramref name="name"/> does not have a <see cref="Buffer.BufferSize"/> that is evenly divisable by the size of <typeparamref name="T"/>.</exception>
         public Array(string name)
-            : base(name, 0, false)
+            : base(name, 0, false, NoFile)
         {
             _elementSize = Marshal.SizeOf(typeof(T));
 

--- a/SharedMemory/BufferReadWrite.cs
+++ b/SharedMemory/BufferReadWrite.cs
@@ -46,8 +46,29 @@ namespace SharedMemory
         /// </summary>
         /// <param name="name">The name of the shared memory to create</param>
         /// <param name="bufferSize">The size of the buffer</param>
+        public BufferReadWrite(string name, int bufferSize, string fileName)
+            : base(name, bufferSize, true, fileName)
+        {
+            Open();
+        }
+
+        /// <summary>
+        /// Creates a new shared memory buffer with the specified name and size
+        /// </summary>
+        /// <param name="name">The name of the shared memory to create</param>
+        /// <param name="bufferSize">The size of the buffer</param>
         public BufferReadWrite(string name, int bufferSize)
-            : base(name, bufferSize, true)
+            : base(name, bufferSize, true, NoFile)
+        {
+            Open();
+        }
+
+        /// <summary>
+        /// Opens an existing shared memory buffer with the specified name
+        /// </summary>
+        /// <param name="name">The name of the shared memory to open</param>
+        public BufferReadWrite(string name, string fileName)
+            : base(name, 0, false, fileName)
         {
             Open();
         }
@@ -57,7 +78,7 @@ namespace SharedMemory
         /// </summary>
         /// <param name="name">The name of the shared memory to open</param>
         public BufferReadWrite(string name)
-            : base(name, 0, false)
+            : base(name, 0, false, NoFile)
         {
             Open();
         }

--- a/SharedMemory/BufferWithLocks.cs
+++ b/SharedMemory/BufferWithLocks.cs
@@ -65,8 +65,8 @@ namespace SharedMemory
         /// <param name="name">The name of the shared memory</param>
         /// <param name="bufferSize">The buffer size in bytes.</param>
         /// <param name="ownsSharedMemory">Whether or not the current instance owns the shared memory. If true a new shared memory will be created and initialised otherwise an existing one is opened.</param>
-        protected BufferWithLocks(string name, long bufferSize, bool ownsSharedMemory)
-            : base(name, bufferSize, ownsSharedMemory)
+        protected BufferWithLocks(string name, long bufferSize, bool ownsSharedMemory, string fileName)
+            : base(name, bufferSize, ownsSharedMemory, fileName)
         {
             WriteWaitEvent = new EventWaitHandle(true, EventResetMode.ManualReset, Name + "_evt_write");
             ReadWaitEvent = new EventWaitHandle(true, EventResetMode.ManualReset, Name + "_evt_read");

--- a/SharedMemory/CircularBuffer.cs
+++ b/SharedMemory/CircularBuffer.cs
@@ -223,8 +223,14 @@ namespace SharedMemory
         /// </code>
         /// </para>
         /// </remarks>
+        public CircularBuffer(string name, int nodeCount, int nodeBufferSize, string fileName)
+            : this(name, nodeCount, nodeBufferSize, true, fileName)
+        {
+            Open();
+        }
+
         public CircularBuffer(string name, int nodeCount, int nodeBufferSize)
-            : this(name, nodeCount, nodeBufferSize, true)
+            : this(name, nodeCount, nodeBufferSize, true, NoFile)
         {
             Open();
         }
@@ -233,14 +239,20 @@ namespace SharedMemory
         /// Opens an existing <see cref="CircularBuffer"/> with the specified name.
         /// </summary>
         /// <param name="name">The name of an existing <see cref="CircularBuffer"/> previously created with <see cref="Buffer.IsOwnerOfSharedMemory"/>=true</param>
-        public CircularBuffer(string name)
-            : this(name, 0, 0, false)
+        public CircularBuffer(string name, string fileName)
+            : this(name, 0, 0, false, fileName)
         {
             Open();
         }
 
-        private CircularBuffer(string name, int nodeCount, int nodeBufferSize, bool ownsSharedMemory)
-            : base(name, Marshal.SizeOf(typeof(NodeHeader)) + (Marshal.SizeOf(typeof(Node)) * nodeCount) + (nodeCount * (long)nodeBufferSize), ownsSharedMemory)
+        public CircularBuffer(string name)
+            : this(name, 0, 0, false, NoFile)
+        {
+            Open();
+        }
+
+        private CircularBuffer(string name, int nodeCount, int nodeBufferSize, bool ownsSharedMemory, string fileName)
+            : base(name, Marshal.SizeOf(typeof(NodeHeader)) + (Marshal.SizeOf(typeof(Node)) * nodeCount) + (nodeCount * (long)nodeBufferSize), ownsSharedMemory, fileName)
         {
             #region Argument validation
             if (ownsSharedMemory && nodeCount < 2)

--- a/SharedMemoryTests/ArrayTests.cs
+++ b/SharedMemoryTests/ArrayTests.cs
@@ -26,6 +26,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SharedMemory;
 using System.Runtime.InteropServices;
@@ -80,6 +81,33 @@ namespace SharedMemoryTests
                     Assert.AreEqual(55, rarraySlice[3], "");
                 }
 
+            }
+        }
+
+        [TestMethod]
+        public void Indexer_ReadWriteInteger_DataMatches_UsingFile()
+        {
+            var fileName = Path.GetTempFileName();
+            try
+            {
+                var name = Guid.NewGuid().ToString();
+                using (var sma = new Array<int>(name, 10, fileName))
+                {
+                    sma[0] = 3;
+                    sma[4] = 10;
+
+                    using (var smr = new Array<int>(name))
+                    {
+                        Assert.AreEqual(0, smr[1], "");
+                        Assert.AreEqual(3, smr[0], "");
+                        Assert.AreEqual(10, smr[4], "");
+                    }
+                }
+
+            }
+            finally
+            {
+                File.Delete(fileName);
             }
         }
 


### PR DESCRIPTION
Shared-memory support typically supports file-based on persisted virtual-memory based memory-based files.

This library currently does an excellent job for virtual-method based memory-based file access, but for those who want to share memory using memory-mapped files backed up by a physical file, it's missing the needed API.

This pull request does the following:
1.  Supplies the constructor overloads that will allow the user to specify a file to use for the memory-mapped file APIs.
2.  For the pre-.NET 4 support, adds the necessary memory-mapped file support to facilitate the API.
3.  Adds a unit test to demonstrate and validate the usage.

