### PR TITLE
Target netstandard20 instead of netcoreapp20

### DIFF
--- a/SharedMemory.nuspec
+++ b/SharedMemory.nuspec
@@ -53,7 +53,7 @@ Usage: http://sharedmemory.codeplex.com/documentation</description>
           <group targetFramework=".NETFramework3.5" />
           <group targetFramework=".NETFramework4.0" />
           <group targetFramework=".NETFramework4.5" />
-          <group targetFramework=".NETCoreApp2.0" />
+          <group targetFramework=".NETStandard2.0" />
         </dependencies>     
     </metadata>
     <files>
@@ -66,8 +66,8 @@ Usage: http://sharedmemory.codeplex.com/documentation</description>
         <file src=".\bin\Release\Net35\SharedMemory.dll" target="lib\net35" />
         <file src=".\bin\Release\Net35\SharedMemory.pdb" target="lib\net35" />
         <file src=".\bin\Release\Net35\SharedMemory.xml" target="lib\net35" />
-        <file src=".\bin\Release\netcoreapp2.0\SharedMemory.dll" target="lib\netcoreapp2.0" />
-        <file src=".\bin\Release\netcoreapp2.0\SharedMemory.xml" target="lib\netcoreapp2.0" />
+        <file src=".\bin\Release\netstandard2.0\SharedMemory.dll" target="lib\netstandard2.0" />
+        <file src=".\bin\Release\netstandard2.0\SharedMemory.xml" target="lib\netstandard2.0" />
         <file src=".\SharedMemory\**\*.cs" target="src" />
     </files>
 </package>

--- a/SharedMemory/SharedMemory.csproj
+++ b/SharedMemory/SharedMemory.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net45;net4;net35</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net45;net4;net35</TargetFrameworks>
     <OutputPath>..\bin\$(Configuration)\</OutputPath>
     <DocumentationFile>..\bin\$(Configuration)\$(TargetFramework)\SharedMemory.xml</DocumentationFile>
   </PropertyGroup>
@@ -14,7 +14,7 @@
     <Copyright>Copyright (c) 2018 Justin Stenning</Copyright>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0'">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
     <DefineConstants>NETCORE;NETCORE2_0;NET40Plus</DefineConstants>
   </PropertyGroup>
 
@@ -29,5 +29,17 @@
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net35'">
     <DefineConstants>NET35;NETFULL</DefineConstants>
   </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
+    <PackageReference Include="System.Reflection.Emit.Lightweight">
+      <Version>4.3.0</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Reflection.Emit.Lightweight">
+      <Version>4.3.0</Version>
+    </PackageReference>
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Netcoreapp20 assemblies can't be consumed in netstandard20 (or net47+) - the net461 assemblies will be preferred, causing annoying compatibility warnings and yellow signs in VS Dependencies.

Targeting netstandard20 instead covers all bases.

Should fix issue #33.