### PR TITLE
Add ignore Exceptions to ProcessCallHandler in RPC Buffer

### DIFF
--- a/SharedMemory/RpcBuffer.cs
+++ b/SharedMemory/RpcBuffer.cs
@@ -977,10 +977,15 @@ namespace SharedMemory
                                 {
                                     await ProcessCallHandler(request).ConfigureAwait(false);
                                 }
-                                catch
+                                catch(Exception ex)
                                 {
-                                    // Ignore exceptions because either the other side of the rpc buffers may 
+                                    // Ignore Object Disposed and Invalid Operation Exceptions
+                                    // because the other side of the rpc buffers may 
                                     // not know if this Buffer is shutting down or disposed
+                                    if (!(ex is ObjectDisposedException || ex is InvalidOperationException))
+                                    {
+                                        throw;
+                                    }                               
                                 }
                             });
                         }


### PR DESCRIPTION
Because as we used the RPC Buffers we had some exceptions wich let to a crash of our application, with message 
```
System.ObjectDisposedException
Cannot access a disposed object.
Object name: 'RpcBuffer'. 
```
I decided to investigate this application and found out that Exceptions on sending Response messages are not handled. So i decided to fix this and add  a in my mind proper handling of possible exceptions, by ignoring them. This will hopefully help also others to increase the stability using this Library. Feel free to ask any questions or to add comments to this.